### PR TITLE
Python 2 xrange -> Python 3 range

### DIFF
--- a/src/backoff_simulator.py
+++ b/src/backoff_simulator.py
@@ -4,6 +4,13 @@
 import heapq
 import random
 
+def xrange(a, b):
+    import sys
+    if sys.version_info.major >= 3:
+        return __builtins__.range(a, b)
+    else:
+        return __builtins__.xrange(a, b)
+
 # Net models the natural delay and variance of the network
 class Net:
     def __init__(self, mean, sd):


### PR DESCRIPTION
*Description of changes:*

Enabling the simulator to run on Python 3 by adding a thin compatibility layer that switch between Python 2 `xrange` built-in and Python 3 equivalent `range` built-in.

References:

- [range() vs xrange() in Python - GeeksforGeeks](https://www.geeksforgeeks.org/range-vs-xrange-python/)
- [Python 3's range is more powerful than Python 2's xrange - Trey Hunner](https://treyhunner.com/2018/02/python-3-s-range-better-than-python-2-s-xrange/)
- [python - Why is there no xrange function in Python3? - Stack Overflow](https://stackoverflow.com/questions/15014310/why-is-there-no-xrange-function-in-python3)
